### PR TITLE
Corrected class check of the date column in vfisvalid.

### DIFF
--- a/source/R/vf.R
+++ b/source/R/vf.R
@@ -167,7 +167,7 @@ vfisvalid <- function(vf) {
     return(FALSE)
   }
   # check date does have Date class
-  if(class(vf$date) != "Date") {
+  if(!inherits(vf$date, "Date")) {
     warning("Field 'date' must be sucessfully converted to 'Date' class", call. = FALSE)
     return(FALSE)
   }


### PR DESCRIPTION
The `inherits()`-function should be used to check whether the date columns is of class "Date", because a variable can inherit from several classes. The previous approach (i.e. `class(vf$date) != "Date"`) can cause problems when "Date" is not the first entry in the class vector, and will at least create a warning when vf$date has several class attributes.